### PR TITLE
Fixes for simple cases in French numbers (#2087)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/NumbersDefinitions.cs
@@ -24,15 +24,15 @@ namespace Microsoft.Recognizers.Definitions.French
       public const string LangMarker = @"Fre";
       public const bool CompoundNumberLanguage = false;
       public const bool MultiDecimalSeparatorCulture = true;
-      public const string RoundNumberIntegerRegex = @"(cent|mille|millions|million|milliard|milliards|billion|billions)";
-      public const string ZeroToNineIntegerRegex = @"(et un|un|une|deux|trois|quatre|cinq|six|sept|huit|neuf)";
+      public const string RoundNumberIntegerRegex = @"(cent|mille|millions?|milliards?|billions?)";
+      public const string ZeroToNineIntegerRegex = @"(une?|deux|trois|quatre|cinq|six|sept|huit|neuf)";
       public const string TenToNineteenIntegerRegex = @"((seize|quinze|quatorze|treize|douze|onze)|dix(\Wneuf|\Whuit|\Wsept)?)";
       public const string TensNumberIntegerRegex = @"(quatre\Wvingt(s|\Wdix)?|soixante\Wdix|vingt|trente|quarante|cinquante|soixante|septante|octante|huitante|nonante)";
       public const string DigitsNumberRegex = @"\d|\d{1,3}(\.\d{3})";
       public const string NegativeNumberTermsRegex = @"^[.]";
       public static readonly string NegativeNumberSignRegex = $@"^({NegativeNumberTermsRegex}\s+).*";
       public static readonly string HundredsNumberIntegerRegex = $@"(({ZeroToNineIntegerRegex}(\s+cent))|cent|((\s+cent\s)+{TensNumberIntegerRegex}))";
-      public static readonly string BelowHundredsRegex = $@"(({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}([-\s]+({TenToNineteenIntegerRegex}|{ZeroToNineIntegerRegex}))?))|{ZeroToNineIntegerRegex})";
+      public static readonly string BelowHundredsRegex = $@"(({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}((-|(\s+et)?\s+)({TenToNineteenIntegerRegex}|{ZeroToNineIntegerRegex}))?))|{ZeroToNineIntegerRegex})";
       public static readonly string BelowThousandsRegex = $@"(({HundredsNumberIntegerRegex}(\s+{BelowHundredsRegex})?|{BelowHundredsRegex}|{TenToNineteenIntegerRegex})|cent\s+{TenToNineteenIntegerRegex})";
       public static readonly string SupportThousandsRegex = $@"(({BelowThousandsRegex}|{BelowHundredsRegex})\s+{RoundNumberIntegerRegex}(\s+{RoundNumberIntegerRegex})?)";
       public static readonly string SeparaIntRegex = $@"({SupportThousandsRegex}(\s+{SupportThousandsRegex})*(\s+{BelowThousandsRegex})?|{BelowThousandsRegex})";
@@ -43,26 +43,26 @@ namespace Microsoft.Recognizers.Definitions.French
       public const string NumbersWithDozenSuffix = @"(((?<!\d+\s*)-\s*)|(?<=\b))\d+\s+douzaine(s)?(?=\b)";
       public static readonly string AllIntRegexWithLocks = $@"((?<=\b){AllIntRegex}(?=\b))";
       public static readonly string AllIntRegexWithDozenSuffixLocks = $@"(?<=\b)(((demi\s+)?\s+douzaine)|({AllIntRegex}\s+douzaines?))(?=\b)";
-      public const string SimpleRoundOrdinalRegex = @"(centi[eè]me|milli[eè]me|millioni[eè]me|milliardi[eè]me|billioni[eè]me)";
-      public const string OneToNineOrdinalRegex = @"(premier|premi[eè]re|deuxi[eè]me|second[e]|troisi[eè]me|tiers|tierce|quatri[eè]me|cinqui[eè]me|sixi[eè]me|septi[eè]me|huiti[eè]me|neuvi[eè]me)";
-      public const string SpecialUnderHundredOrdinalRegex = @"(onzi[eè]me|douzi[eè]me)";
-      public const string TensOrdinalRegex = @"(quatre-vingt-dixi[eè]me|quatre-vingti[eè]me|huitanti[eè]me|octanti[eè]me|soixante-dixi[eè]me|septanti[eè]me|soixanti[eè]me|cinquanti[eè]me|quaranti[eè]me|trenti[eè]me|vingti[eè]me)";
-      public static readonly string HundredOrdinalRegex = $@"({AllIntRegex}(\s+(centi[eè]me\s)))";
-      public static readonly string UnderHundredOrdinalRegex = $@"((({AllIntRegex}(\W)?)?{OneToNineOrdinalRegex})|({TensNumberIntegerRegex}(\W)?)?{OneToNineOrdinalRegex}|{TensOrdinalRegex}|{SpecialUnderHundredOrdinalRegex})";
-      public static readonly string UnderThousandOrdinalRegex = $@"((({HundredOrdinalRegex}(\s)?)?{UnderHundredOrdinalRegex})|(({AllIntRegex}(\W)?)?{SimpleRoundOrdinalRegex})|{HundredOrdinalRegex})";
-      public static readonly string OverThousandOrdinalRegex = $@"(({AllIntRegex})(i[eè]me))";
+      public const string SimpleRoundOrdinalRegex = @"(centi|[bm]illioni|milli(ardi)?)[eè]me";
+      public const string OneToNineOrdinalRegex = @"(premi[eè]re?|second[e]|tier(s|ce)|(deuxi|troisi|quatri|cinqui|sixi|septi|hui[tr]i|neuvi)[eè]me)";
+      public const string SpecialUnderHundredOrdinalRegex = @"(di[xz]i|onzi|douzi|treizi|quatorzi|quinzi|seizi|dix[\s-](septi|huiri|neuvi))[eè]me";
+      public const string TensOrdinalRegex = @"(quatre-vingt-di[xz]i[eè]me|quatre-vingti[eè]me|huitanti[eè]me|octanti[eè]me|soixante-dixi[eè]me|septanti[eè]me|soixanti[eè]me|cinquanti[eè]me|quaranti[eè]me|trenti[eè]me|vingti[eè]me)";
+      public static readonly string HundredOrdinalRegex = $@"({AllIntRegex}(\s+(centi[eè]me)))";
+      public static readonly string UnderHundredOrdinalRegex = $@"(((({AllIntRegex}|{TensNumberIntegerRegex})(\W)?)?({OneToNineOrdinalRegex}|\s+et\s+uni[eè]me))|{SpecialUnderHundredOrdinalRegex}|{TensOrdinalRegex})";
+      public static readonly string UnderThousandOrdinalRegex = $@"((({HundredOrdinalRegex}(\s|-)?)?{UnderHundredOrdinalRegex})|(({AllIntRegex}(\W)?)?{SimpleRoundOrdinalRegex})|{HundredOrdinalRegex})";
+      public static readonly string OverThousandOrdinalRegex = $@"(({AllIntRegex})(-i[eè]me))";
       public static readonly string ComplexOrdinalRegex = $@"(({OverThousandOrdinalRegex}(\s)?)?{UnderThousandOrdinalRegex}|{OverThousandOrdinalRegex}|{UnderHundredOrdinalRegex})";
       public static readonly string SuffixOrdinalRegex = $@"(({AllIntRegex})({SimpleRoundOrdinalRegex}))";
       public static readonly string ComplexRoundOrdinalRegex = $@"((({SuffixOrdinalRegex}(\s)?)?{ComplexOrdinalRegex})|{SuffixOrdinalRegex})";
       public static readonly string AllOrdinalRegex = $@"({ComplexOrdinalRegex}|{SimpleRoundOrdinalRegex}|{ComplexRoundOrdinalRegex})";
       public const string PlaceHolderPureNumber = @"\b";
       public const string PlaceHolderDefault = @"\D|\b";
-      public const string OrdinalSuffixRegex = @"(?<=\b)((\d*(1er|2e|2eme|3e|3eme|4e|4eme|5e|5eme|6e|6eme|7e|7eme|8e|8eme|9e|9eme|0e|0eme))|(11e|11eme|12e|12eme))(?=\b)";
+      public const string OrdinalSuffixRegex = @"(?<=\b)((\d*(1[eè]re|1er|2e|2eme|3e|3eme|4e|4eme|5e|5eme|6e|6eme|7e|7eme|8e|8eme|9e|9eme|0e|0eme))|(11e|11eme|12e|12eme))(?=\b)";
       public static readonly string OrdinalFrenchRegex = $@"(?<=\b){AllOrdinalRegex}(?=\b)";
       public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
       public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
-      public static readonly string FractionNounRegex = $@"(?<=\b)({AllIntRegex}\s+((et)\s+)?)?({AllIntRegex})(\s+((et)\s)?)((({AllOrdinalRegex})s?|({SuffixOrdinalRegex})s?)|demis?|tiers?|quarts?)(?=\b)";
-      public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)({AllIntRegex}\s+(et\s+)?)?(un|une)(\s+)(({AllOrdinalRegex})|({SuffixOrdinalRegex})|(et\s+)?demis?)(?=\b)";
+      public static readonly string FractionNounRegex = $@"(?<=\b)({AllIntRegex}\s+((et)\s+)?)?({AllIntRegex})(\s+((et)\s)?)((({AllOrdinalRegex})s?|({SuffixOrdinalRegex})s?)|demi[es]?|tiers?|quarts?)(?=\b)";
+      public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)({AllIntRegex}\s+(et\s+)?)?(une?)(\s+)(({AllOrdinalRegex})|({SuffixOrdinalRegex})|(et\s+)?demi[es]?)(?=\b)";
       public static readonly string FractionPrepositionRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<!\.)\d+))\s+sur\s+(?<denominator>({AllIntRegex})|((\d+)(?!\.)))(?=\b)";
       public static readonly string AllPointRegex = $@"((\s+{ZeroToNineIntegerRegex})+|(\s+{SeparaIntRegex}))";
       public static readonly string AllFloatRegex = $@"({AllIntRegex}(\s+(virgule|point)){AllPointRegex})";
@@ -84,7 +84,7 @@ namespace Microsoft.Recognizers.Definitions.French
       public static readonly string[] WrittenGroupSeparatorTexts = { @"point", @"points" };
       public static readonly string[] WrittenIntegerSeparatorTexts = { @"et", @"-" };
       public static readonly string[] WrittenFractionSeparatorTexts = { @"et", @"sur" };
-      public const string HalfADozenRegex = @"(?<=\b)demi\s+douzaine";
+      public const string HalfADozenRegex = @"(?<=\b)demie?\s+douzaine";
       public static readonly string DigitalNumberRegex = $@"((?<=\b)(cent|mille|million|millions|milliard|milliards|billions|billion|douzaine(s)?)(?=\b))|((?<=(\d|\b)){BaseNumbers.MultiplierLookupRegex}(?=\b))";
       public const string AmbiguousFractionConnectorsRegex = @"^[.]";
       public static readonly Dictionary<string, long> CardinalNumberMap = new Dictionary<string, long>
@@ -110,6 +110,7 @@ namespace Microsoft.Recognizers.Definitions.French
             { @"seize", 16 },
             { @"dix-sept", 17 },
             { @"dix-huit", 18 },
+            { @"dix-huir", 18 },
             { @"dix-neuf", 19 },
             { @"vingt", 20 },
             { @"trente", 30 },
@@ -157,12 +158,15 @@ namespace Microsoft.Recognizers.Definitions.French
             { @"premier", 1 },
             { @"première", 1 },
             { @"premiere", 1 },
+            { @"unième", 1 },
+            { @"unieme", 1 },
             { @"deuxième", 2 },
             { @"deuxieme", 2 },
             { @"second", 2 },
             { @"seconde", 2 },
             { @"troisième", 3 },
             { @"demi", 2 },
+            { @"demie", 2 },
             { @"tiers", 3 },
             { @"tierce", 3 },
             { @"quart", 4 },
@@ -178,10 +182,14 @@ namespace Microsoft.Recognizers.Definitions.French
             { @"septieme", 7 },
             { @"huitième", 8 },
             { @"huitieme", 8 },
+            { @"huirième", 8 },
+            { @"huirieme", 8 },
             { @"neuvième", 9 },
             { @"neuvieme", 9 },
             { @"dixième", 10 },
             { @"dixieme", 10 },
+            { @"dizième", 10 },
+            { @"dizieme", 10 },
             { @"onzième", 11 },
             { @"onzieme", 11 },
             { @"douzième", 12 },
@@ -189,7 +197,7 @@ namespace Microsoft.Recognizers.Definitions.French
             { @"treizième", 13 },
             { @"treizieme", 13 },
             { @"quatorzième", 14 },
-            { @"quatorizieme", 14 },
+            { @"quatorzieme", 14 },
             { @"quinzième", 15 },
             { @"quinzieme", 15 },
             { @"seizième", 16 },
@@ -198,6 +206,8 @@ namespace Microsoft.Recognizers.Definitions.French
             { @"dix-septieme", 17 },
             { @"dix-huitième", 18 },
             { @"dix-huitieme", 18 },
+            { @"dix-huirième", 18 },
+            { @"dix-huirieme", 18 },
             { @"dix-neuvième", 19 },
             { @"dix-neuvieme", 19 },
             { @"vingtième", 20 },

--- a/.NET/Samples/SimpleConsole/Program.cs
+++ b/.NET/Samples/SimpleConsole/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Choice;
@@ -27,7 +28,7 @@ namespace SimpleConsole
                 var input = Console.ReadLine()?.Trim();
                 Console.WriteLine();
 
-                if (input?.ToLower() == "exit")
+                if (input?.ToLower(CultureInfo.InvariantCulture) == "exit")
                 {
                     // Close application if user types "exit"
                     break;

--- a/Patterns/French/French-Numbers.yaml
+++ b/Patterns/French/French-Numbers.yaml
@@ -7,9 +7,9 @@ CompoundNumberLanguage: !bool false
 MultiDecimalSeparatorCulture: !bool true
 #Integer Regex
 RoundNumberIntegerRegex: !simpleRegex
-  def: (cent|mille|millions|million|milliard|milliards|billion|billions)
+  def: (cent|mille|millions?|milliards?|billions?)
 ZeroToNineIntegerRegex: !simpleRegex
-  def: (et un|un|une|deux|trois|quatre|cinq|six|sept|huit|neuf)
+  def: (une?|deux|trois|quatre|cinq|six|sept|huit|neuf)
 TenToNineteenIntegerRegex: !simpleRegex
   def: ((seize|quinze|quatorze|treize|douze|onze)|dix(\Wneuf|\Whuit|\Wsept)?)
 TensNumberIntegerRegex: !simpleRegex
@@ -27,7 +27,7 @@ HundredsNumberIntegerRegex: !nestedRegex
   def: (({ZeroToNineIntegerRegex}(\s+cent))|cent|((\s+cent\s)+{TensNumberIntegerRegex}))
   references: [ ZeroToNineIntegerRegex, TensNumberIntegerRegex ]
 BelowHundredsRegex: !nestedRegex
-  def: (({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}([-\s]+({TenToNineteenIntegerRegex}|{ZeroToNineIntegerRegex}))?))|{ZeroToNineIntegerRegex})
+  def: (({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}((-|(\s+et)?\s+)({TenToNineteenIntegerRegex}|{ZeroToNineIntegerRegex}))?))|{ZeroToNineIntegerRegex})
   references: [ TenToNineteenIntegerRegex, TensNumberIntegerRegex, ZeroToNineIntegerRegex ]
 BelowThousandsRegex: !nestedRegex
   def: (({HundredsNumberIntegerRegex}(\s+{BelowHundredsRegex})?|{BelowHundredsRegex}|{TenToNineteenIntegerRegex})|cent\s+{TenToNineteenIntegerRegex})
@@ -60,25 +60,25 @@ AllIntRegexWithDozenSuffixLocks: !nestedRegex
   references: [ AllIntRegex ]
 #Ordinal Regex
 SimpleRoundOrdinalRegex: !simpleRegex
-  def: (centi[eè]me|milli[eè]me|millioni[eè]me|milliardi[eè]me|billioni[eè]me)
+  def: (centi|[bm]illioni|milli(ardi)?)[eè]me
 OneToNineOrdinalRegex: !simpleRegex
-  def: (premier|premi[eè]re|deuxi[eè]me|second[e]|troisi[eè]me|tiers|tierce|quatri[eè]me|cinqui[eè]me|sixi[eè]me|septi[eè]me|huiti[eè]me|neuvi[eè]me)
+  def: (premi[eè]re?|second[e]|tier(s|ce)|(deuxi|troisi|quatri|cinqui|sixi|septi|hui[tr]i|neuvi)[eè]me)
 SpecialUnderHundredOrdinalRegex: !simpleRegex
-  def: (onzi[eè]me|douzi[eè]me)
+  def: (di[xz]i|onzi|douzi|treizi|quatorzi|quinzi|seizi|dix[\s-](septi|huiri|neuvi))[eè]me
 TensOrdinalRegex: !simpleRegex
-  def: (quatre-vingt-dixi[eè]me|quatre-vingti[eè]me|huitanti[eè]me|octanti[eè]me|soixante-dixi[eè]me|septanti[eè]me|soixanti[eè]me|cinquanti[eè]me|quaranti[eè]me|trenti[eè]me|vingti[eè]me)
+  def: (quatre-vingt-di[xz]i[eè]me|quatre-vingti[eè]me|huitanti[eè]me|octanti[eè]me|soixante-dixi[eè]me|septanti[eè]me|soixanti[eè]me|cinquanti[eè]me|quaranti[eè]me|trenti[eè]me|vingti[eè]me)
 HundredOrdinalRegex: !nestedRegex
   # un centieme, deux centieme, trois centieme, etc
-  def: ({AllIntRegex}(\s+(centi[eè]me\s)))
+  def: ({AllIntRegex}(\s+(centi[eè]me)))
   references: [ AllIntRegex ]
 UnderHundredOrdinalRegex: !nestedRegex
-  def: ((({AllIntRegex}(\W)?)?{OneToNineOrdinalRegex})|({TensNumberIntegerRegex}(\W)?)?{OneToNineOrdinalRegex}|{TensOrdinalRegex}|{SpecialUnderHundredOrdinalRegex})
+  def: (((({AllIntRegex}|{TensNumberIntegerRegex})(\W)?)?({OneToNineOrdinalRegex}|\s+et\s+uni[eè]me))|{SpecialUnderHundredOrdinalRegex}|{TensOrdinalRegex})
   references: [ AllIntRegex, OneToNineOrdinalRegex, TensNumberIntegerRegex, TensOrdinalRegex, SpecialUnderHundredOrdinalRegex ]
 UnderThousandOrdinalRegex: !nestedRegex
-  def: ((({HundredOrdinalRegex}(\s)?)?{UnderHundredOrdinalRegex})|(({AllIntRegex}(\W)?)?{SimpleRoundOrdinalRegex})|{HundredOrdinalRegex})
+  def: ((({HundredOrdinalRegex}(\s|-)?)?{UnderHundredOrdinalRegex})|(({AllIntRegex}(\W)?)?{SimpleRoundOrdinalRegex})|{HundredOrdinalRegex})
   references: [ HundredOrdinalRegex, UnderHundredOrdinalRegex, AllIntRegex, SimpleRoundOrdinalRegex ]
 OverThousandOrdinalRegex: !nestedRegex
-  def: (({AllIntRegex})(i[eè]me))
+  def: (({AllIntRegex})(-i[eè]me))
   references: [ AllIntRegex ]
 ComplexOrdinalRegex: !nestedRegex
   def: (({OverThousandOrdinalRegex}(\s)?)?{UnderThousandOrdinalRegex}|{OverThousandOrdinalRegex}|{UnderHundredOrdinalRegex})
@@ -97,7 +97,7 @@ PlaceHolderPureNumber: !simpleRegex
 PlaceHolderDefault: !simpleRegex
   def: \D|\b
 OrdinalSuffixRegex: !simpleRegex
-  def: (?<=\b)((\d*(1er|2e|2eme|3e|3eme|4e|4eme|5e|5eme|6e|6eme|7e|7eme|8e|8eme|9e|9eme|0e|0eme))|(11e|11eme|12e|12eme))(?=\b)
+  def: (?<=\b)((\d*(1[eè]re|1er|2e|2eme|3e|3eme|4e|4eme|5e|5eme|6e|6eme|7e|7eme|8e|8eme|9e|9eme|0e|0eme))|(11e|11eme|12e|12eme))(?=\b)
 OrdinalFrenchRegex: !nestedRegex
   def: (?<=\b){AllOrdinalRegex}(?=\b)
   references: [ AllOrdinalRegex ]
@@ -107,10 +107,10 @@ FractionNotationWithSpacesRegex: !simpleRegex
 FractionNotationRegex: !simpleRegex
   def: (((?<=\W|^)-\s*)|(?<=\b))\d+[/]\d+(?=(\b[^/]|$))
 FractionNounRegex: !nestedRegex
-  def: (?<=\b)({AllIntRegex}\s+((et)\s+)?)?({AllIntRegex})(\s+((et)\s)?)((({AllOrdinalRegex})s?|({SuffixOrdinalRegex})s?)|demis?|tiers?|quarts?)(?=\b)
+  def: (?<=\b)({AllIntRegex}\s+((et)\s+)?)?({AllIntRegex})(\s+((et)\s)?)((({AllOrdinalRegex})s?|({SuffixOrdinalRegex})s?)|demi[es]?|tiers?|quarts?)(?=\b)
   references: [ AllIntRegex, AllOrdinalRegex, SuffixOrdinalRegex ]
 FractionNounWithArticleRegex: !nestedRegex
-  def: (?<=\b)({AllIntRegex}\s+(et\s+)?)?(un|une)(\s+)(({AllOrdinalRegex})|({SuffixOrdinalRegex})|(et\s+)?demis?)(?=\b)
+  def: (?<=\b)({AllIntRegex}\s+(et\s+)?)?(une?)(\s+)(({AllOrdinalRegex})|({SuffixOrdinalRegex})|(et\s+)?demi[es]?)(?=\b)
   references: [ AllIntRegex, AllOrdinalRegex, SuffixOrdinalRegex ]
 FractionPrepositionRegex: !nestedRegex
   def: (?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<!\.)\d+))\s+sur\s+(?<denominator>({AllIntRegex})|((\d+)(?!\.)))(?=\b)
@@ -159,7 +159,7 @@ WrittenGroupSeparatorTexts: [point, points]
 WrittenIntegerSeparatorTexts: [et, '-']
 WrittenFractionSeparatorTexts: [et, sur]
 HalfADozenRegex: !simpleRegex
-  def: (?<=\b)demi\s+douzaine
+  def: (?<=\b)demie?\s+douzaine
 DigitalNumberRegex: !nestedRegex
   def: ((?<=\b)(cent|mille|million|millions|milliard|milliards|billions|billion|douzaine(s)?)(?=\b))|((?<=(\d|\b)){BaseNumbers.MultiplierLookupRegex}(?=\b))
   references: [ BaseNumbers.MultiplierLookupRegex ]
@@ -190,6 +190,7 @@ CardinalNumberMap: !dictionary
     seize: 16
     dix-sept: 17
     dix-huit: 18
+    dix-huir: 18
     dix-neuf: 19
     vingt: 20
     trente: 30
@@ -237,12 +238,15 @@ OrdinalNumberMap: !dictionary
     premier: 1
     première: 1
     premiere: 1
+    unième: 1
+    unieme: 1
     deuxième: 2
     deuxieme: 2
     second: 2
     seconde: 2
     troisième: 3
     demi: 2
+    demie: 2
     tiers: 3
     tierce: 3
     quart: 4
@@ -258,10 +262,14 @@ OrdinalNumberMap: !dictionary
     septieme: 7
     huitième: 8
     huitieme: 8
+    huirième: 8
+    huirieme: 8
     neuvième: 9
     neuvieme: 9
     dixième: 10
     dixieme: 10
+    dizième: 10
+    dizieme: 10
     onzième: 11
     onzieme: 11
     douzième: 12
@@ -269,7 +277,7 @@ OrdinalNumberMap: !dictionary
     treizième: 13
     treizieme: 13
     quatorzième: 14
-    quatorizieme: 14
+    quatorzieme: 14
     quinzième: 15
     quinzieme: 15
     seizième: 16
@@ -278,6 +286,8 @@ OrdinalNumberMap: !dictionary
     dix-septieme: 17
     dix-huitième: 18
     dix-huitieme: 18
+    dix-huirième: 18
+    dix-huirieme: 18
     dix-neuvième: 19
     dix-neuvieme: 19
     vingtième: 20

--- a/Specs/Number/French/NumberModel.json
+++ b/Specs/Number/French/NumberModel.json
@@ -1690,5 +1690,103 @@
         }
       }
     ]
+  },
+  {
+    "Input": "sous la pluie et un vent glacial",
+    "NotSupported": "python",
+    "Results": [
+      {
+        "Text": "un",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1"
+        },
+        "Start": 17,
+        "End": 18
+      }
+    ]
+  },
+  {
+    "Input": "vingt et un ou plus",
+    "NotSupported": "python",
+    "Results": [
+      {
+        "Text": "vingt et un",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "21"
+        },
+        "Start": 0,
+        "End": 10
+      }
+    ]
+  },
+  {
+    "Input": "vingt et un ou vingt-deux",
+    "NotSupported": "python",
+    "Results": [
+      {
+        "Text": "vingt et un",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "21"
+        },
+        "Start": 0,
+        "End": 10
+      },
+      {
+        "Text": "vingt-deux",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "22"
+        },
+        "Start": 15,
+        "End": 24
+      }
+    ]
+  },
+  {
+    "Input": "quatre centièmes de seconde",
+    "NotSupported": "python",
+    "Results": [
+      {
+        "Text": "quatre centièmes",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,04"
+        },
+        "Start": 0,
+        "End": 15
+      }
+    ]
+  },
+  {
+    "Input": "et une bonne jour née",
+    "NotSupported": "python",
+    "Results": [
+      {
+        "Text": "une",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1"
+        },
+        "Start": 3,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "un vingt et unieme",
+    "Results": [
+      {
+        "Text": "un vingt et unieme",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,0476190476190476"
+        },
+        "Start": 0,
+        "End": 17
+      }
+    ]
   }
 ]

--- a/Specs/Number/French/OrdinalModel.json
+++ b/Specs/Number/French/OrdinalModel.json
@@ -386,5 +386,102 @@
         "End": 44
       }
     ]
+  },
+  {
+    "Input": "Son dizième anniversaire",
+    "Results": [
+      {
+        "Text": "dizième",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "value": "10",
+          "offset":"10",
+          "relativeTo":"start"
+        },
+        "Start": 4,
+        "End": 10
+      }
+    ]
+  },
+  {
+    "Input": "1ère femme",
+    "Results": [
+      {
+        "Text": "1ère",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "value": "1",
+          "offset":"1",
+          "relativeTo":"start"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "quinzième, dix-huirième, dix-septième, septième",
+    "Results": [
+      {
+        "Text": "quinzième",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "value": "15",
+          "offset":"15",
+          "relativeTo":"start"
+        },
+        "Start": 0,
+        "End": 8
+      },
+      {
+        "Text": "dix-huirième",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "value": "18",
+          "offset":"18",
+          "relativeTo":"start"
+        },
+        "Start": 11,
+        "End": 22
+      },
+      {
+        "Text": "dix-septième",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "value": "17",
+          "offset":"17",
+          "relativeTo":"start"
+        },
+        "Start":25,
+        "End": 36
+      },
+      {
+        "Text": "septième",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "value": "7",
+          "offset":"7",
+          "relativeTo":"start"
+        },
+        "Start": 39,
+        "End": 46
+      }
+    ]
+  },
+  {
+    "Input": "Le vingt et unième jour",
+    "Results": [
+      {
+        "Text": "vingt et unième",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "value": "21",
+          "offset":"21",
+          "relativeTo":"start"
+        },
+        "Start": 3,
+        "End": 17
+      }
+    ]
   }
 ]


### PR DESCRIPTION
* Fixes for simple cases in French numbers.

* Adding new spec cases.

* Ordinal fixes and extensions in French.

* Added temporary marker to avoid false positives. To be fixed later.